### PR TITLE
docs: replace generic-template link for contributors widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Certifique-se de ler esses arquivos com atenção antes de contribuir. Se tiver 
 
 ## ❤️ Quem já Contribuiu
 
-<a href="https://github.com/cumbucadev/generic-template/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=cumbucadev/generic-template" />
+<a href="https://github.com/cumbucadev/shared-workflows/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cumbucadev/shared-workflows" />
 </a></br></br>
 
 _Made with [contrib.rocks](https://contrib.rocks)._

--- a/README_EN.md
+++ b/README_EN.md
@@ -76,7 +76,7 @@ Make sure to read these files carefully before contributing. If you have any dif
 
 ## ❤️ Contributors
 
-[![contributors](https://contrib.rocks/image?repo=cumbucadev/generic-template)](https://github.com/cumbucadev/generic-template/graphs/contributors)
+[![contributors](https://contrib.rocks/image?repo=cumbucadev/shared-workflows)](https://github.com/cumbucadev/shared-workflows/graphs/contributors)
 
 _Made with [contrib.rocks](https://contrib.rocks)._
 


### PR DESCRIPTION
closes #5 