### PR TITLE
ci: rename semantic-pull-request workflow

### DIFF
--- a/.github/workflows/validate-pr-title-v1.yml
+++ b/.github/workflows/validate-pr-title-v1.yml
@@ -1,4 +1,4 @@
-name: "Lint PR"
+name: "Validate PR title"
 
 on:
   workflow_call:
@@ -13,98 +13,110 @@ permissions:
 
 jobs:
   main:
-    name: Validate PR title
+    name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        id: lint_pr_title
+      - name: Validate PR title format
+        uses: amannn/action-semantic-pull-request@v5
+        id: validate
         with:
           types: |
+            build
             chore
             ci
             docs
             feat
             fix
+            perf
             refactor
+            revert
             style
             test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - name: Post comment with PR title error
+        uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
-        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        if: always() && (steps.validate.outputs.error_message != null)
         with:
-          header: pr-title-lint-error
+          header: pr-title-error
           message: |
-            📌 Esta mensagem está tanto em português quanto em inglês (mais abaixo)  — assim todo mundo consegue acompanhar!  
+            📌 Esta mensagem está tanto em português quanto em inglês (mais abaixo)  — assim todo mundo consegue acompanhar!
             📌 This message is in both Portuguese and English (further down) — so everyone can follow along!
-          
+
             🇧🇷 **Português**
-          
-            Oi! Muito obrigada por abrir esse pull request 💜 
-          
-            Por aqui, seguimos o padrão do [**Conventional Commits**](https://www.conventionalcommits.org/pt-br/v1.0.0/) para os **títulos das PRs**.  
+
+            Oi! Muito obrigada por abrir esse pull request 💜
+
+            Por aqui, seguimos o padrão do [**Conventional Commits**](https://www.conventionalcommits.org/pt-br/v1.0.0/) para os **títulos das PRs**.
             Esse padrão ajuda a manter o histórico do projeto organizado e claro.
-          
+
             No seu caso, o título do PR precisa de um pequeno ajuste pra ficar dentro desse formato. Isso é super comum no começo, então suaveee!
-          
+
             👉 Um título válido geralmente começa com um prefixo como:
+            - `build:` para mudanças no sistema de build ou dependências externas
             - `chore:` para tarefas de manutenção
             - `ci:` para integrações contínuas
             - `docs:` para mudanças na documentação
             - `feat:` para novas funcionalidades
             - `fix:` para correções de bugs
+            - `perf:` para melhorias de performance
             - `refactor:` para melhorias internas no código
+            - `revert:` para reverter um commit anterior
             - `style:` para mudanças de formatação
             - `test:` para adição ou ajustes de testes
-          
-            Esses são só alguns exemplos — a [documentação oficial](https://www.conventionalcommits.org/pt-br/v1.0.0/) tem mais opções e explicações.  
-          
+
+            Esses são só alguns exemplos — a [documentação oficial](https://www.conventionalcommits.org/pt-br/v1.0.0/) tem mais opções e explicações.
+
             **Antes de seguir com o PR, dá uma olhadinha lá pra entender bem o padrão — isso vai te ajudar bastante nesta e em futuras contribuições também.**
-          
+
             O título atual está assim (fora do padrão esperado):
-            
+
             ```
-            ${{ steps.lint_pr_title.outputs.error_message }}
+            ${{ steps.validate.outputs.error_message }}
             ```
-          
+
             Qualquer dúvida, é só chamar por aqui! Estamos aqui para te ajudar!
-          
+
             🇬🇧 **English**
-          
-            Hey there and thank you for opening this pull request! 💜  
-          
-            In this project, we follow the [**Conventional Commits**](https://www.conventionalcommits.org/en/v1.0.0/) specification for **PR titles**.  
+
+            Hey there and thank you for opening this pull request! 💜
+
+            In this project, we follow the [**Conventional Commits**](https://www.conventionalcommits.org/en/v1.0.0/) specification for **PR titles**.
             This helps keep the commit history organized and clean.
-          
+
             In your case, the PR title needs a small adjustment to match the expected format. Totally normal if this is your first time — no stress!
-          
+
             👉 A valid PR title usually starts with a prefix like:
+            - `build:` for build system or external dependency changes
             - `chore:` for maintenance tasks
             - `ci:` for continuous integration changes
             - `docs:` for documentation updates
             - `feat:` for new features
             - `fix:` for bug fixes
+            - `perf:` for performance improvements
             - `refactor:` for internal code improvements
-            - `style:` for formatting
+            - `revert:` for reverting a previous commit
+            - `style:` for formatting changes
             - `test:` for test additions or changes
-          
-            These are just a few examples — the [official documentation](https://www.conventionalcommits.org/en/v1.0.0/) has more options and great explanations.  
+
+            These are just a few examples — the [official documentation](https://www.conventionalcommits.org/en/v1.0.0/) has more options and great explanations.
             **Before continuing with the PR, we recommend reading it — it'll really help with this and future contributions.**
-          
+
             💡 Here's the current title (which doesn't follow the expected format):
-          
+
             ```
-            ${{ steps.lint_pr_title.outputs.error_message }}
+            ${{ steps.validate.outputs.error_message }}
             ```
-          
+
             Let us know if you need help updating it — we’re here to support you!
 
       # Delete a previous comment when the issue has been resolved
-      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+      - name: Remove previous PR title error comment
+        if: ${{ steps.validate.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          header: pr-title-lint-error
+          header: pr-title-error
           delete: true

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ organização.
    * [O que tem aqui?](#o-que-tem-aqui)
    * [Como usar em outros repositórios](#como-usar-em-outros-repositórios)
    * [Catálogo](#catálogo)
-      + [semantic-pull-request](#semantic-pull-request)
+      + [validate-pr-title](#validate-pr-title)
    * [💬 Novos Funcionalidades e Reportar Bugs](#-novos-funcionalidades-e-reportar-bugs)
    * [💡 Dúvidas? Ideias?](#-dúvidas-ideias)
    * [💻 Contribuindo com o Código do Projeto](#-contribuindo-com-o-código-do-projeto)
@@ -59,7 +59,7 @@ Exemplo real de uso:
 ```yml
 jobs:
   exemplo:
-    uses: cumbucadev/shared-workflows/.github/workflows/semantic-pull-request-v1.yml@main
+    uses: cumbucadev/shared-workflows/.github/workflows/validate-pr-title-v1.yml@main
 ```
 
 ## Catálogo
@@ -68,7 +68,7 @@ Abaixo estão os workflows compartilhados atualmente usados na organização Cum
 versionamento **pela major no nome do arquivo** (ex.: `-v1`, `-v2`). Veja o changelog para mudanças
 quebráveis e notas de migração.
 
-### semantic-pull-request
+### validate-pr-title
 
 #### Descrição
 
@@ -86,7 +86,7 @@ documentação oficial. Assim que o título for corrigido, o comentário é remo
 #### Resumo de comportamento
 
 - Valida os títulos de PRs contra uma lista permitida de tipos do Conventional Commits:
-  - `chore`, `ci`, `docs`, `feat`, `fix`, `refactor`, `style`, `test`
+  - `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
 - Se inválido:
   - Falha o check
   - Publica um comentário fixo com contexto, exemplos e links em PT-BR e EN

--- a/README_EN.md
+++ b/README_EN.md
@@ -22,7 +22,7 @@ Central repository with **reusable GitHub Actions workflows** for the organizati
    * [What's in here?](#whats-in-here)
    * [How to use in other repositories](#how-to-use-in-other-repositories)
    * [Catalog](#catalog)
-      + [semantic-pull-request](#semantic-pull-request)
+      + [validate-pr-title](#validate-pr-title)
    * [💬 New Features and Reporting Bugs](#-new-features-and-reporting-bugs)
    * [💡 Questions? Ideas?](#-questions-ideas)
    * [💻 Contributing to the Project's Code](#-contributing-to-the-projects-code)
@@ -55,7 +55,7 @@ Real example of use:
 ```yml
 jobs:
   example:
-    uses: cumbucadev/shared-workflows/.github/workflows/semantic-pull-request-v1.yml@main
+    uses: cumbucadev/shared-workflows/.github/workflows/validate-pr-title-v1.yml@main
 ```
 
 ## Catalog
@@ -63,7 +63,7 @@ jobs:
 Below are the shared workflows currently used across the Cumbuca org. We version **by major in the
 filename** (e.g., `-v1`, `-v2`). See the changelogs for breaking changes and migration notes.
 
-### semantic-pull-request
+### validate-pr-title
 
 #### Description
 
@@ -80,8 +80,8 @@ official docs for guidance. Once the title is fixed, the comment is automaticall
 
 #### Behavior summary
 
-- Validates PR titles against an allowed list of Conventional Commit types:
-  - `chore`, `ci`, `docs`, `feat`, `fix`, `refactor`, `style`, `test`
+- Validates PR titles against the allowed list of Conventional Commit types:
+  - `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
 - If invalid:
   - Fails the check
   - Posts a sticky comment with context, examples, and links in both PT-BR and EN


### PR DESCRIPTION
**Description**

1. Rename the workflow to follow the `verb + target` naming pattern.
1. Add a `name:` to each job step to improve readability and debugging.
1. Include the missing prefixes from the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
1. Update the validate job `id` to match the naming convention used across the file (using the word `validate` instead of `lint`)
1. Update the message `header` to match the naming convention used across the file (using the word `validate` instead of `lint`)
1. Update docs

Closes #11