### PR TITLE
feat: autoassign-issue workflow

### DIFF
--- a/.github/workflows/autoassign-issue-v1.yaml
+++ b/.github/workflows/autoassign-issue-v1.yaml
@@ -1,0 +1,69 @@
+name: Autoassign Issue
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  issue_assign:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request == null
+    concurrency:
+      group: ${{ github.actor }}-issue-assign
+      cancel-in-progress: true
+
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      ASSIGNEE: ${{ github.event.comment.user.login }}
+      CONTRIBUTING_URL: https://github.com/${{ github.repository }}/blob/main/CONTRIBUTING.md
+
+    steps:
+      - name: Check if comment matches trigger words
+        id: check_comment
+        run: |
+          comment="${{ github.event.comment.body }}"
+          comment_lower=$(echo "$comment" | tr '[:upper:]' '[:lower:]')
+
+          triggers=("bora" "bora!" "dibs" "dibs!")
+
+          should_assign=false
+
+          for word in "${triggers[@]}"; do
+            if [[ "$comment_lower" == "$word" ]]; then
+              should_assign=true
+              break
+            fi
+          done
+
+          echo "should_assign=$should_assign" >> $GITHUB_OUTPUT
+
+      - name: Assign issue to commenter
+        if: steps.check_comment.outputs.should_assign == 'true'
+        run: |
+          echo "::notice::Assigning issue #$ISSUE_NUMBER to $ASSIGNEE"
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/assignees \
+            -d '{"assignees":["${{ env.ASSIGNEE }}"]}'
+
+      - name: Create Comment
+        if: steps.check_comment.outputs.should_assign == 'true'
+        uses: peter-evans/create-or-update-comment@v5.0.0
+        with:
+          issue-number: ${{ env.ISSUE_NUMBER }}
+          body: |
+            🇧🇷 **Português**
+            ✅ Issue #${{ github.event.issue.number }} atribuída a @${{ github.event.comment.user.login }}. Verifique o [guia de contribuição](${{ env.CONTRIBUTING_URL }}) para instruções sobre como submeter sua Pull Request.
+
+            🇬🇧 **English**
+            ✅ Issue #${{ github.event.issue.number }} assigned to @${{ github.event.comment.user.login }}. Check the [contributing guide](${{ env.CONTRIBUTING_URL }}) for instructions on submitting your Pull Request.

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Repositório central com **workflows reutilizáveis** do GitHub Actions para os 
 organização.
 
 - [Shared Workflows](#shared-workflows)
-   * [O que tem aqui?](#o-que-tem-aqui)
-   * [Como usar em outros repositórios](#como-usar-em-outros-repositórios)
-   * [Catálogo](#catálogo)
-      + [validate-pr-title](#validate-pr-title)
-   * [💬 Novos Funcionalidades e Reportar Bugs](#-novos-funcionalidades-e-reportar-bugs)
-   * [💡 Dúvidas? Ideias?](#-dúvidas-ideias)
-   * [💻 Contribuindo com o Código do Projeto](#-contribuindo-com-o-código-do-projeto)
-   * [❤️ Quem já Contribuiu](#-quem-já-contribuiu)
+  - [O que tem aqui?](#o-que-tem-aqui)
+  - [Como usar em outros repositórios](#como-usar-em-outros-repositórios)
+  - [Catálogo](#catálogo)
+    - [validate-pr-title](#validate-pr-title)
+  - [💬 Novos Funcionalidades e Reportar Bugs](#-novos-funcionalidades-e-reportar-bugs)
+  - [💡 Dúvidas? Ideias?](#-dúvidas-ideias)
+  - [💻 Contribuindo com o Código do Projeto](#-contribuindo-com-o-código-do-projeto)
+  - [❤️ Quem já Contribuiu](#-quem-já-contribuiu)
 
 ## O que tem aqui?
 
@@ -67,6 +67,40 @@ jobs:
 Abaixo estão os workflows compartilhados atualmente usados na organização Cumbuca. Fazemos o
 versionamento **pela major no nome do arquivo** (ex.: `-v1`, `-v2`). Veja o changelog para mudanças
 quebráveis e notas de migração.
+
+### autoassign-issue
+
+#### Descrição
+
+Este workflow atribui automaticamente uma issue a um usuário quando ele comenta uma **palavra-chave específica** na issue.
+O comentário funciona como um gatilho de “quero assumir esta issue”, tornando o processo de autoatribuição simples, rápido e transparente.
+Além disso, o workflow publica um comentário bilíngue (português + inglês) confirmando que a issue foi atribuída ao usuário.
+
+#### Gatilhos
+
+- `issue_comment` (created)
+
+#### Palavras-chave (triggers)
+
+- `"bora"`, `"bora!"`, `"dibs"`, `"dibs!"`
+  _(case-insensitive — qualquer variação de maiúsculas/minúsculas é aceita)_
+
+#### Resumo de comportamento
+
+- Quando alguém comenta uma das palavras-chave em uma issue aberta:
+
+  - A issue é automaticamente atribuída a esse usuário
+  - Um comentário bilíngue é publicado confirmando a atribuição e incluindo link para o guia de contribuição
+
+- Facilita o processo de contribuição, evitando trabalho manual de manutenção de assignees e melhorando a visibilidade de quem está trabalhando em cada issue
+
+#### Changelog
+
+- **v1** — Lançamento inicial
+
+  - Implementa autoassign para comentários com palavras-chave específicas
+  - Palavras-chave suportadas: `"bora"`, `"bora!"`, `"dibs"`, `"dibs!"`
+  - Inclui comentário de confirmação bilíngue (PT-BR + EN)
 
 ### validate-pr-title
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -19,14 +19,14 @@
 Central repository with **reusable GitHub Actions workflows** for the organization's repositories.
 
 - [Shared Workflows](#shared-workflows)
-   * [What's in here?](#whats-in-here)
-   * [How to use in other repositories](#how-to-use-in-other-repositories)
-   * [Catalog](#catalog)
-      + [validate-pr-title](#validate-pr-title)
-   * [💬 New Features and Reporting Bugs](#-new-features-and-reporting-bugs)
-   * [💡 Questions? Ideas?](#-questions-ideas)
-   * [💻 Contributing to the Project's Code](#-contributing-to-the-projects-code)
-   * [❤️ Contributors](#-contributors)
+  - [What's in here?](#whats-in-here)
+  - [How to use in other repositories](#how-to-use-in-other-repositories)
+  - [Catalog](#catalog)
+    - [validate-pr-title](#validate-pr-title)
+  - [💬 New Features and Reporting Bugs](#-new-features-and-reporting-bugs)
+  - [💡 Questions? Ideas?](#-questions-ideas)
+  - [💻 Contributing to the Project's Code](#-contributing-to-the-projects-code)
+  - [❤️ Contributors](#-contributors)
 
 ## What's in here?
 
@@ -63,6 +63,40 @@ jobs:
 Below are the shared workflows currently used across the Cumbuca org. We version **by major in the
 filename** (e.g., `-v1`, `-v2`). See the changelogs for breaking changes and migration notes.
 
+### autoassign-issue
+
+#### Description
+
+This workflow automatically assigns an issue to a user when they comment a **specific keyword** on the issue.
+The comment works as a trigger of “I want to take this issue,” making the self-assignment process simple, fast, and transparent.
+Additionally, the workflow posts a bilingual (English + Portuguese) comment confirming that the issue has been assigned to the user.
+
+#### Triggers
+
+- `issue_comment` (created)
+
+#### Keywords (triggers)
+
+- `"bora"`, `"bora!"`, `"dibs"`, `"dibs!"`
+  _(case-insensitive — any combination of uppercase/lowercase letters is accepted)_
+
+#### Behavior Summary
+
+- When someone comments one of the trigger keywords on an open issue:
+
+  - The issue is automatically assigned to that user
+  - A bilingual comment is posted confirming the assignment and including a link to the contributing guide
+
+- Helps streamline the contribution process, avoiding manual assignee management and improving visibility of who is working on each issue
+
+#### Changelog
+
+- **v1** — Initial release
+
+  - Implements autoassign for comments containing specific trigger keywords
+  - Supported keywords: `"bora"`, `"bora!"`, `"dibs"`, `"dibs!"`
+  - Posts a bilingual confirmation comment (PT-BR + EN)
+
 ### validate-pr-title
 
 #### Description
@@ -88,13 +122,13 @@ official docs for guidance. Once the title is fixed, the comment is automaticall
 - If valid:
   - Removes any previous error comment
 - Helps maintain a clean, standardized project history, improving automation (e.g., changelogs,
-releases)
+  releases)
 
 #### Changelog
 
 - **v1** — Initial release.
   - Enforces allowed Conventional Commit types (`chore`, `ci`, `docs`, `feat`, `fix`, `refactor`,
-  `style`, `test`)
+    `style`, `test`)
   - Adds bilingual guidance for contributors when the title is invalid
   - Automatically cleans up guidance comments once the title is fixed
 


### PR DESCRIPTION
This workflow automatically assigns an issue to a user when they comment a **specific keyword** on the issue.
The comment acts as a trigger for “I want to take this issue,” making the self-assignment process **simple, fast, and transparent**.

Additionally, the workflow posts a **bilingual (English + Portuguese) comment** confirming that the issue has been assigned to the user.

You can test it and see it in action here: [issue #7](https://github.com/cumbucadev/actionando/issues/7)

<img width="939" height="280" alt="image" src="https://github.com/user-attachments/assets/760774ea-3fd2-4f1a-b421-3ea114030d1d" />

Closes #19 