### PR TITLE
fix: handling special-character comments on autoassign-issue

### DIFF
--- a/.github/workflows/autoassign-issue-v1.yml
+++ b/.github/workflows/autoassign-issue-v1.yml
@@ -27,22 +27,23 @@ jobs:
     steps:
       - name: Check if comment matches trigger words
         id: check_comment
+        env:
+          COMMENT: "${{ github.event.comment.body }}"
         run: |
-          comment="${{ github.event.comment.body }}"
-          comment_lower=$(echo "$comment" | tr '[:upper:]' '[:lower:]')
+          normalized_comment=$(echo "$COMMENT" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
 
           triggers=("bora" "bora!" "dibs" "dibs!")
 
           should_assign=false
 
           for word in "${triggers[@]}"; do
-            if [[ "$comment_lower" == "$word" ]]; then
+            if [[ "$normalized_comment" == "$word" ]]; then
               should_assign=true
               break
             fi
           done
 
-          echo "should_assign=$should_assign" >> $GITHUB_OUTPUT
+          echo "should_assign=$should_assign" >> "$GITHUB_OUTPUT"
 
       - name: Assign issue to commenter
         if: steps.check_comment.outputs.should_assign == 'true'


### PR DESCRIPTION
**Description**

To verify and test the current implementation:

* Workflow file: [`[.github/workflows/autoassign-issue-v1.yaml](https://github.com/cumbucadev/actionando/blob/main/.github/workflows/autoassign-issue-v1.yaml)`](https://github.com/cumbucadev/actionando/blob/main/.github/workflows/autoassign-issue-v1.yaml)
* Related issue for context: [[#7](https://github.com/cumbucadev/actionando/issues/7)](https://github.com/cumbucadev/actionando/issues/7)

This issue addresses problems with handling multi-line comments, emojis, and special characters when checking triggers in the workflow.

Closes: #29